### PR TITLE
Restore live download counter

### DIFF
--- a/README.md
+++ b/README.md
@@ -2,7 +2,7 @@
 
 [![License: GPL v3](https://img.shields.io/badge/License-GPLv3-blue.svg)](https://www.gnu.org/licenses/gpl-3.0)
 [![F-Droid](https://img.shields.io/f-droid/v/com.github.mistermo_vibecode.voiceplus.svg?logo=f-droid)](https://f-droid.org/packages/com.github.mistermo_vibecode.voiceplus/)
-[![Downloads](https://img.shields.io/badge/downloads-200%2B-brightgreen)](https://github.com/Mistermo-vibecode/VoicePlus/releases)
+[![Downloads](https://img.shields.io/github/downloads/Mistermo-vibecode/VoicePlus/total.svg)](https://github.com/Mistermo-vibecode/VoicePlus/releases)
 [![CI](https://github.com/Mistermo-vibecode/VoicePlus/actions/workflows/ci.yml/badge.svg)](https://github.com/Mistermo-vibecode/VoicePlus/actions/workflows/ci.yml)
 
 A fork of [Voice](https://github.com/PaulWoitaschek/Voice) by Paul Woitaschek — a genuinely great audiobook app that I enjoyed but wanted something a bit different for myself. 


### PR DESCRIPTION
## What changed

Restore the Shields GitHub release-download badge so the displayed number updates automatically from current release assets.

## Why

The temporary `200+` badge was a static label and therefore was not a real counter. GitHub cannot restore download counts belonging to a deleted release asset, so the live counter resumes from the surviving assets' total.

## Validation

- `git diff --check`
- the branch changes only `README.md`
