### PR TITLE
Fix F-Droid release version detection

### DIFF
--- a/app/build.gradle.kts
+++ b/app/build.gradle.kts
@@ -39,8 +39,9 @@ android {
 
   defaultConfig {
     applicationId = "com.github.mistermo_vibecode.voiceplus"
-    versionName = releaseVersionNameOverride.getOrElse("1.24")
-    versionCode = releaseVersionCodeOverride.map(String::toInt).getOrElse(5408001)
+    // Keep these as literals so F-Droid's tag checker can discover releases.
+    versionName = "1.24"
+    versionCode = 5408001
 
     testInstrumentationRunner = "voice.app.VoiceJUnitRunner"
   }
@@ -129,6 +130,15 @@ android {
 }
 
 androidComponents {
+  onVariants(selector().withBuildType("release")) { variant ->
+    if (releaseVersionNameOverride.isPresent) {
+      variant.outputs.forEach { output ->
+        output.versionName.set(releaseVersionNameOverride)
+        output.versionCode.set(releaseVersionCodeOverride.map(String::toInt))
+      }
+    }
+  }
+
   onVariants(selector().withBuildType("debug")) { variant ->
     if (debugVersionNameOverride.isPresent) {
       variant.outputs.forEach { output ->


### PR DESCRIPTION
## What changed

- keep the default version name and code as literals in `app/build.gradle.kts`
- apply tester-release version overrides through Android variant outputs

## Why

F-Droid's tag checker could not discover v1.24 because the version declarations were provider expressions. Literal defaults restore automatic release detection while preserving tester-release overrides.

## Validation

- `:app:lintLibreDebug`
- `voiceUnitTest`
- `lintKotlin`
- `:app:assembleLibreDebug`
- `:app:assembleLibreRelease`
- verified default APK metadata: `1.24` / `5408001`
- verified override APK metadata: `test-v1.24-test1` / `5408000`
