### PR TITLE
Fix playback speed bug (setting not persisted)

### DIFF
--- a/core/playback/src/main/kotlin/voice/core/playback/player/VoicePlayer.kt
+++ b/core/playback/src/main/kotlin/voice/core/playback/player/VoicePlayer.kt
@@ -5,6 +5,7 @@ import androidx.datastore.core.DataStore
 import androidx.media3.common.C
 import androidx.media3.common.ForwardingPlayer
 import androidx.media3.common.MediaItem
+import androidx.media3.common.PlaybackParameters
 import androidx.media3.common.Player
 import androidx.media3.exoplayer.ExoPlayer
 import androidx.media3.exoplayer.PlayerMessage
@@ -427,10 +428,10 @@ class VoicePlayer(
     }
   }
 
-  override fun setPlaybackSpeed(speed: Float) {
-    super.setPlaybackSpeed(speed)
+  override fun setPlaybackParameters(playbackParameters: PlaybackParameters) {
+    super.setPlaybackParameters(playbackParameters)
     scope.launch {
-      updateBook { it.copy(playbackSpeed = speed) }
+      updateBook { it.copy(playbackSpeed = playbackParameters.speed)}
     }
   }
 


### PR DESCRIPTION
The fix is to override setPlaybackParameters instead of setPlaybackSpeed in VoicePlayer.

The reason this is necessary is that VoicePlus introduced LockscreenPlayer, registering it as the player for PlaybackService instead of VoicePlayer (forwarding to VoicePlayer). LockscreenPlayer extends the newer ForwardingSimpleBasePlayer, which descends from BasePlayer, which actually locks its implementation of setPlaybackSpeed (calling setPlaybackParameters) as 'final'.

As a result, ForwardingSimpleBasePlayer does not forward to the setPlaybackSpeed of its given player. It instead calls setPlaybackParameters. Thus, the setPlaybackSpeed override in VoicePlayer was not ever called.

I've just tested this in the emulator, and it resolves both issues I was observing here: https://github.com/mistermo-vibecode/VoicePlus/issues/16#issue-5273043418

Fair warning: I'm not an Android developer. I just happened to have Android Studio installed and really wanted this feature fixed. I'll see if I can get this version loaded onto my phone.