### PR TITLE
Release v1.27

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -49,7 +49,7 @@ jobs:
         run: >-
           ./gradlew :app:voiceDeviceLibreDebugAndroidTest
           -Pandroid.testoptions.manageddevices.emulator.gpu=swiftshader_indirect
-          -Pandroid.testInstrumentationRunnerArguments.class=voice.app.AppLaunchSmokeTest,voice.app.SleepTimerIntegrationTest
+          -Pandroid.testInstrumentationRunnerArguments.class=voice.app.AppLaunchSmokeTest,voice.app.SleepTimerIntegrationTest,voice.app.FeatureRegressionTest,voice.app.AndroidAutoMediaButtonTest
       - name: Publish JUnit Report
         uses: mikepenz/action-junit-report@v6
         if: always()

--- a/README.md
+++ b/README.md
@@ -19,11 +19,11 @@ But you can try both. If the features below add value to your listening experien
 
 ---
 
-## What's new in v1.26
+## What's new in v1.27
 
-- Redesigned Listening Statistics with clearer records, finished-book details, and relisten counts
-- Playback speed changes are now remembered — thanks [@tomwhat](https://github.com/tomwhat)
-- More reliable Android restore of listening history and cover art
+- Later Chapter Fix corrections preserve earlier chapter names and respect restored names
+- Long-press menus work in search results — thanks [@JamesDBartlett3](https://github.com/JamesDBartlett3)
+- Android Auto forward/rewind keys keep the correct direction without changing headset preferences — thanks [@geofgowan](https://github.com/geofgowan) for reporting
 
 ---
 

--- a/app/build.gradle.kts
+++ b/app/build.gradle.kts
@@ -40,8 +40,8 @@ android {
   defaultConfig {
     applicationId = "com.github.mistermo_vibecode.voiceplus"
     // Keep these as literals so F-Droid's tag checker can discover releases.
-    versionName = "1.26"
-    versionCode = 5408003
+    versionName = "1.27"
+    versionCode = 5408004
 
     testInstrumentationRunner = "voice.app.VoiceJUnitRunner"
   }

--- a/app/src/androidTest/kotlin/voice/app/AndroidAutoMediaButtonTest.kt
+++ b/app/src/androidTest/kotlin/voice/app/AndroidAutoMediaButtonTest.kt
@@ -1,0 +1,166 @@
+package voice.app
+
+import android.content.Context
+import android.content.Intent
+import android.os.Bundle
+import android.os.Process
+import android.view.KeyEvent
+import androidx.datastore.core.DataStore
+import androidx.media3.common.MediaItem
+import androidx.media3.common.Player
+import androidx.media3.session.MediaSession
+import androidx.test.core.app.ApplicationProvider
+import androidx.test.ext.junit.runners.AndroidJUnit4
+import androidx.test.platform.app.InstrumentationRegistry
+import dev.zacsweers.metro.GraphExtension
+import dev.zacsweers.metro.Inject
+import io.kotest.matchers.shouldBe
+import kotlinx.coroutines.CoroutineScope
+import kotlinx.coroutines.Dispatchers
+import kotlinx.coroutines.cancel
+import kotlinx.coroutines.delay
+import kotlinx.coroutines.flow.first
+import kotlinx.coroutines.runBlocking
+import kotlinx.coroutines.withContext
+import kotlinx.coroutines.withTimeout
+import org.junit.Test
+import org.junit.runner.RunWith
+import voice.core.common.rootGraphAs
+import voice.core.data.MediaButtonClickAction
+import voice.core.data.store.MediaButtonDoubleClickHandlerStore
+import voice.core.data.store.MediaButtonTripleClickHandlerStore
+import voice.core.data.store.SeekTimeStore
+import voice.core.playback.di.PlaybackScope
+import voice.core.playback.history.ListeningEventRecorder
+import voice.core.playback.playstate.PositionUpdater
+import voice.core.playback.session.LibrarySessionCallback
+import java.io.File
+
+@RunWith(AndroidJUnit4::class)
+class AndroidAutoMediaButtonTest {
+
+  @field:[Inject MediaButtonDoubleClickHandlerStore]
+  lateinit var doubleClickStore: DataStore<MediaButtonClickAction>
+
+  @field:[Inject MediaButtonTripleClickHandlerStore]
+  lateinit var tripleClickStore: DataStore<MediaButtonClickAction>
+
+  @field:[Inject SeekTimeStore]
+  lateinit var seekTimeStore: DataStore<Int>
+
+  @Test
+  fun carKeysKeepTheirDirectionWhileHeadsetKeysRemainConfigurable() = runBlocking {
+    val root = rootGraphAs<TestGraph>()
+    root.inject(this@AndroidAutoMediaButtonTest)
+    val previousDouble = doubleClickStore.data.first()
+    val previousTriple = tripleClickStore.data.first()
+    val previousSeek = seekTimeStore.data.first()
+    val context = ApplicationProvider.getApplicationContext<Context>()
+    val audio = File.createTempFile("car-media-keys-", ".m4a", context.cacheDir)
+    InstrumentationRegistry.getInstrumentation().context.assets.open("auphonic_chapters_demo.m4a").use { input ->
+      audio.outputStream().use { input.copyTo(it) }
+    }
+
+    // Use production dependencies and real playback, but synthetic controller identities: this
+    // covers the car callback boundary, not Android Auto's head-unit UI or controller attribution.
+    val graph = withContext(Dispatchers.Main) { root.mediaButtonTestGraphFactory.create() }
+    var session: MediaSession? = null
+    try {
+      doubleClickStore.updateData { MediaButtonClickAction.SKIP_BACKWARD }
+      tripleClickStore.updateData { MediaButtonClickAction.SKIP_FORWARD }
+      seekTimeStore.updateData { 10 }
+      withContext(Dispatchers.Main) {
+        session = MediaSession.Builder(context, graph.player)
+          .setId("car-media-buttons-test")
+          .setCallback(graph.callback)
+          .build()
+        graph.player.setMediaItem(MediaItem.fromUri(audio.toURI().toString()))
+        graph.player.prepare()
+      }
+      val activeSession = checkNotNull(session)
+      withTimeout(10_000) {
+        while (withContext(Dispatchers.Main) { graph.player.playbackState != Player.STATE_READY }) delay(20)
+      }
+
+      for (packageName in listOf(
+        "com.google.android.projection.gearhead",
+        "com.android.car.media",
+        "com.android.car.carlauncher",
+        "com.android.bluetooth",
+      )) {
+        val isCar = packageName != "com.android.bluetooth"
+        val controller = MediaSession.ControllerInfo.createTestOnlyControllerInfo(
+          packageName,
+          Process.myPid(),
+          Process.myUid(),
+          0,
+          0,
+          true,
+          Bundle.EMPTY,
+          true,
+        )
+        withContext(Dispatchers.Main) {
+          (activeSession.isAutoCompanionController(controller) || activeSession.isAutomotiveController(controller)) shouldBe isCar
+        }
+        for (keyCode in listOf(KeyEvent.KEYCODE_MEDIA_NEXT, KeyEvent.KEYCODE_MEDIA_PREVIOUS)) {
+          withContext(Dispatchers.Main) { graph.player.seekTo(60_000L) }
+          awaitPosition(graph.player, 60_000L)
+          val expected = if ((keyCode == KeyEvent.KEYCODE_MEDIA_NEXT) == isCar) 70_000L else 50_000L
+          withContext(Dispatchers.Main) {
+            graph.callback.onMediaButtonEvent(activeSession, controller, mediaKey(keyCode)) shouldBe true
+          }
+          awaitPosition(graph.player, expected)
+
+          withContext(Dispatchers.Main) {
+            graph.callback.onMediaButtonEvent(activeSession, controller, mediaKey(keyCode, KeyEvent.ACTION_UP)) shouldBe true
+            graph.callback.onMediaButtonEvent(activeSession, controller, mediaKey(keyCode, repeat = 1)) shouldBe true
+          }
+          delay(100)
+          withContext(Dispatchers.Main) { graph.player.currentPosition shouldBe expected }
+        }
+      }
+    } finally {
+      withContext(Dispatchers.Main) {
+        graph.positionUpdater.release()
+        graph.listeningEventRecorder.release()
+        session?.release()
+        graph.player.release()
+        graph.scope.cancel()
+      }
+      doubleClickStore.updateData { previousDouble }
+      tripleClickStore.updateData { previousTriple }
+      seekTimeStore.updateData { previousSeek }
+      audio.delete()
+    }
+  }
+
+  private suspend fun awaitPosition(
+    player: Player,
+    expected: Long,
+  ) = withTimeout(10_000) {
+    while (withContext(Dispatchers.Main) { player.currentPosition != expected }) delay(20)
+  }
+
+  private fun mediaKey(
+    keyCode: Int,
+    action: Int = KeyEvent.ACTION_DOWN,
+    repeat: Int = 0,
+  ) = Intent(Intent.ACTION_MEDIA_BUTTON).putExtra(
+    Intent.EXTRA_KEY_EVENT,
+    KeyEvent(0, 0, action, keyCode, repeat, 0, -1, 0),
+  )
+}
+
+@GraphExtension(scope = PlaybackScope::class)
+interface MediaButtonTestGraph {
+  val player: Player
+  val callback: LibrarySessionCallback
+  val scope: CoroutineScope
+  val positionUpdater: PositionUpdater
+  val listeningEventRecorder: ListeningEventRecorder
+
+  @GraphExtension.Factory
+  interface Factory {
+    fun create(): MediaButtonTestGraph
+  }
+}

--- a/app/src/androidTest/kotlin/voice/app/FeatureRegressionTest.kt
+++ b/app/src/androidTest/kotlin/voice/app/FeatureRegressionTest.kt
@@ -1,0 +1,179 @@
+package voice.app
+
+import androidx.compose.ui.test.ExperimentalTestApi
+import androidx.compose.ui.test.assertIsDisplayed
+import androidx.compose.ui.test.hasClickAction
+import androidx.compose.ui.test.hasScrollToIndexAction
+import androidx.compose.ui.test.hasSetTextAction
+import androidx.compose.ui.test.hasText
+import androidx.compose.ui.test.junit4.createEmptyComposeRule
+import androidx.compose.ui.test.longClick
+import androidx.compose.ui.test.onNodeWithContentDescription
+import androidx.compose.ui.test.onNodeWithText
+import androidx.compose.ui.test.performClick
+import androidx.compose.ui.test.performScrollToNode
+import androidx.compose.ui.test.performTextReplacement
+import androidx.compose.ui.test.performTouchInput
+import androidx.compose.ui.test.waitUntilAtLeastOneExists
+import androidx.datastore.core.DataStore
+import androidx.test.core.app.ActivityScenario
+import androidx.test.espresso.Espresso.pressBack
+import androidx.test.ext.junit.runners.AndroidJUnit4
+import dev.zacsweers.metro.Inject
+import io.kotest.matchers.shouldBe
+import kotlinx.coroutines.flow.first
+import kotlinx.coroutines.runBlocking
+import org.junit.Rule
+import org.junit.Test
+import org.junit.runner.RunWith
+import voice.core.common.rootGraphAs
+import voice.core.data.BookContent
+import voice.core.data.BookId
+import voice.core.data.Chapter
+import voice.core.data.ChapterId
+import voice.core.data.GridMode
+import voice.core.data.MarkData
+import voice.core.data.repo.BookContentRepo
+import voice.core.data.repo.ChapterNameOverrideRepo
+import voice.core.data.repo.ChapterRepo
+import voice.core.data.store.CurrentBookStore
+import voice.core.data.store.GridModeStore
+import voice.core.data.store.OnboardingCompletedStore
+import java.time.Instant
+
+@OptIn(ExperimentalTestApi::class)
+@RunWith(AndroidJUnit4::class)
+class FeatureRegressionTest {
+  @get:Rule
+  @Suppress("DEPRECATION") // The v2 test dispatcher disposes real MediaController listeners off the Android main thread.
+  val compose = createEmptyComposeRule()
+
+  @Inject lateinit var books: BookContentRepo
+
+  @Inject lateinit var chapters: ChapterRepo
+
+  @Inject lateinit var overrides: ChapterNameOverrideRepo
+  @field:[Inject GridModeStore] lateinit var layout: DataStore<GridMode>
+  @field:[Inject OnboardingCompletedStore] lateinit var onboarding: DataStore<Boolean>
+  @field:[Inject CurrentBookStore] lateinit var currentBook: DataStore<BookId?>
+
+  private val bookId = BookId("v127-feature-regression")
+  private val chapterId = ChapterId("file:///v127-feature-regression.m4a")
+  private val title = "V127 Regression Fixture"
+
+  @Test
+  fun gridSearchLongPressOpensMenuAndTapOpensBook() = searchMenu(GridMode.GRID)
+
+  @Test
+  fun listSearchLongPressOpensMenuAndTapOpensBook() = searchMenu(GridMode.LIST)
+
+  private fun searchMenu(mode: GridMode) = withFixture(mode) {
+    ActivityScenario.launch(MainActivity::class.java).use {
+      search()
+      compose.onNode(hasText(title) and hasClickAction() and !hasSetTextAction()).performTouchInput { longClick() }
+      compose.waitUntilAtLeastOneExists(hasText("Name"), 10_000)
+      compose.onNodeWithText("Name").assertIsDisplayed()
+      compose.onNodeWithText("Delete Book").assertIsDisplayed()
+      pressBack()
+      compose.onNode(hasText(title) and hasClickAction() and !hasSetTextAction()).performClick()
+      compose.waitUntilAtLeastOneExists(hasText("Chapter 12"), 10_000)
+      compose.onNodeWithText(title).assertIsDisplayed()
+    }
+  }
+
+  @Test
+  fun chapterCorrectionPersistsAcrossReopenAndResetClearsNames() = withFixture(GridMode.GRID) {
+    ActivityScenario.launch(MainActivity::class.java).use {
+      search()
+      compose.onNode(hasText(title) and hasClickAction() and !hasSetTextAction()).performClick()
+      compose.waitUntilAtLeastOneExists(hasText("Chapter 12"), 10_000)
+      openEditor()
+      repeat(2) { compose.onNodeWithContentDescription("Decrease chapter offset").performClick() }
+      compose.waitUntilAtLeastOneExists(hasText("-2"), 10_000)
+      compose.onNode(hasScrollToIndexAction()).performScrollToNode(hasText("Chapter 8"))
+      compose.onNodeWithText("Chapter 8").assertIsDisplayed()
+      compose.onNodeWithText("Chapter 9").assertIsDisplayed()
+      compose.onNodeWithContentDescription("Close").performClick()
+      openEditor()
+      compose.onNodeWithContentDescription("Decrease chapter offset").performClick()
+      compose.waitUntilAtLeastOneExists(hasText("-3"), 10_000)
+      compose.waitUntil(10_000) {
+        runBlocking { overrides.overridesForBook(bookId).first().size == 2 }
+      }
+      runBlocking {
+        books.get(bookId)!!.chapterNameOffset shouldBe -3
+        overrides.overridesForBook(bookId).first().map { it.name } shouldBe listOf("Chapter 8", "Chapter 9")
+      }
+      compose.onNodeWithContentDescription("More").performClick()
+      compose.onNodeWithText("Reset all to defaults").performClick()
+      compose.onNodeWithText("Reset").performClick()
+      compose.waitUntil(10_000) {
+        runBlocking { books.get(bookId)!!.chapterNameOffset == 0 && overrides.overridesForBook(bookId).first().isEmpty() }
+      }
+      compose.onNodeWithContentDescription("Close").performClick()
+      openEditor()
+      compose.onNode(hasScrollToIndexAction()).performScrollToNode(hasText("Chapter 10"))
+      compose.onNodeWithText("Chapter 10").assertIsDisplayed()
+      compose.onNodeWithText("Chapter 11").assertIsDisplayed()
+      compose.onNodeWithText("0").assertIsDisplayed()
+    }
+  }
+
+  private fun openEditor() {
+    compose.onNodeWithContentDescription("More").performClick()
+    compose.waitUntilAtLeastOneExists(hasText("Chapter Fix"), 10_000)
+    compose.onNodeWithText("Chapter Fix").performClick()
+    compose.waitUntilAtLeastOneExists(hasText("Edit chapter names"), 10_000)
+  }
+
+  private fun search() {
+    compose.waitUntilAtLeastOneExists(hasSetTextAction(), 10_000)
+    compose.onNode(hasSetTextAction()).performClick()
+    // Clearing explicitly also tests returning to an existing search after closing the editor.
+    compose.onNode(hasSetTextAction()).performTextReplacement(title)
+    compose.waitUntilAtLeastOneExists(hasText(title) and hasClickAction() and !hasSetTextAction(), 10_000)
+  }
+
+  private fun withFixture(
+    mode: GridMode,
+    block: () -> Unit,
+  ) {
+    rootGraphAs<TestGraph>().inject(this)
+    val oldLayout = runBlocking { layout.data.first() }
+    val oldOnboarding = runBlocking { onboarding.data.first() }
+    val oldBook = runBlocking { currentBook.data.first() }
+    runBlocking {
+      layout.updateData { mode }
+      onboarding.updateData { true }
+      chapters.put(
+        Chapter(
+          id = chapterId,
+          name = "Regression fixture",
+          duration = 120_000L,
+          fileLastModified = Instant.EPOCH,
+          markData = (0..3).map { MarkData(it * 30_000L, "Chapter ${it + 10}") },
+        ),
+      )
+      overrides.deleteAll(bookId)
+      books.put(
+        BookContent(
+          id = bookId, playbackSpeed = 1f, skipSilence = false, isActive = true,
+          lastPlayedAt = Instant.now(), author = "Regression", name = title, addedAt = Instant.now(),
+          chapters = listOf(chapterId), currentChapter = chapterId, positionInChapter = 65_000L,
+          cover = null, gain = 0f, genre = null, narrator = null, series = null, part = null,
+        ),
+      )
+    }
+    try {
+      block()
+    } finally {
+      runBlocking {
+        books.get(bookId)?.let { books.put(it.copy(isActive = false)) }
+        overrides.deleteAll(bookId)
+        layout.updateData { oldLayout }
+        onboarding.updateData { oldOnboarding }
+        currentBook.updateData { oldBook }
+      }
+    }
+  }
+}

--- a/app/src/androidTest/kotlin/voice/app/TestGraph.kt
+++ b/app/src/androidTest/kotlin/voice/app/TestGraph.kt
@@ -19,6 +19,8 @@ interface TestGraph : AppGraph {
 
   fun inject(target: AndroidAutoMediaButtonTest)
 
+  fun inject(target: FeatureRegressionTest)
+
   val mediaButtonTestGraphFactory: MediaButtonTestGraph.Factory
 
   @DependencyGraph.Factory

--- a/app/src/androidTest/kotlin/voice/app/TestGraph.kt
+++ b/app/src/androidTest/kotlin/voice/app/TestGraph.kt
@@ -17,6 +17,10 @@ interface TestGraph : AppGraph {
 
   fun inject(target: SleepTimerIntegrationTest)
 
+  fun inject(target: AndroidAutoMediaButtonTest)
+
+  val mediaButtonTestGraphFactory: MediaButtonTestGraph.Factory
+
   @DependencyGraph.Factory
   interface Factory {
     fun create(@Provides application: Application): TestGraph

--- a/core/playback/src/main/kotlin/voice/core/playback/session/LibrarySessionCallback.kt
+++ b/core/playback/src/main/kotlin/voice/core/playback/session/LibrarySessionCallback.kt
@@ -310,12 +310,13 @@ class LibrarySessionCallback(
         return true
       }
       // Many earbuds translate double/triple taps into NEXT/PREVIOUS in firmware, so those
-      // keycodes route through the user's configured click actions. A real keyboard's dedicated
-      // next/previous keys must keep their literal meaning, though — otherwise customized click
-      // actions reverse them (GitHub issue #7).
+      // keycodes route through the user's configured click actions. Dedicated keyboard and car
+      // controls must keep their literal direction, regardless of headset settings (#7, #20).
       KeyEvent.KEYCODE_MEDIA_NEXT -> {
-        if (keyEvent.isFromHardwareKeyboard()) {
-          Logger.d("onMediaButtonEvent: NEXT (hardware keyboard)")
+        if (keyEvent.isFromHardwareKeyboard() ||
+          session.isAutoCompanionController(controller) || session.isAutomotiveController(controller)
+        ) {
+          Logger.d("onMediaButtonEvent: NEXT (keyboard/car)")
           player.seekForward()
         } else {
           Logger.d("onMediaButtonEvent: NEXT")
@@ -328,8 +329,10 @@ class LibrarySessionCallback(
         return true
       }
       KeyEvent.KEYCODE_MEDIA_PREVIOUS -> {
-        if (keyEvent.isFromHardwareKeyboard()) {
-          Logger.d("onMediaButtonEvent: PREVIOUS (hardware keyboard)")
+        if (keyEvent.isFromHardwareKeyboard() ||
+          session.isAutoCompanionController(controller) || session.isAutomotiveController(controller)
+        ) {
+          Logger.d("onMediaButtonEvent: PREVIOUS (keyboard/car)")
           player.seekBack()
         } else {
           Logger.d("onMediaButtonEvent: PREVIOUS")

--- a/core/playback/src/test/kotlin/voice/core/playback/session/LibrarySessionCallbackTest.kt
+++ b/core/playback/src/test/kotlin/voice/core/playback/session/LibrarySessionCallbackTest.kt
@@ -1,7 +1,9 @@
 package voice.core.playback.session
 
+import android.content.Intent
 import android.os.Bundle
 import android.view.InputDevice
+import android.view.KeyEvent
 import androidx.media3.session.MediaSession
 import androidx.media3.session.SessionResult
 import io.kotest.matchers.shouldBe
@@ -11,14 +13,123 @@ import io.mockk.just
 import io.mockk.mockk
 import io.mockk.verify
 import io.mockk.verifySequence
+import kotlinx.coroutines.CoroutineScope
+import kotlinx.coroutines.test.advanceUntilIdle
+import kotlinx.coroutines.test.runTest
 import org.junit.Test
 import org.junit.runner.RunWith
 import org.robolectric.RobolectricTestRunner
+import voice.core.data.MediaButtonClickAction
+import voice.core.playback.MemoryDataStore
 import voice.core.playback.history.PlaybackIntentHolder
 import voice.core.playback.player.VoicePlayer
 
 @RunWith(RobolectricTestRunner::class)
 class LibrarySessionCallbackTest {
+
+  @Test
+  fun `Android Auto next and previous ignore reversed headset actions`() = runTest {
+    val player = mockk<VoicePlayer>(relaxed = true)
+    val callback = mediaButtonCallback(player, this)
+    val controller = mockk<MediaSession.ControllerInfo>()
+    val session = mockk<MediaSession>(relaxed = true) {
+      every { isAutoCompanionController(controller) } returns true
+    }
+
+    callback.onMediaButtonEvent(session, controller, mediaKey(KeyEvent.KEYCODE_MEDIA_NEXT)) shouldBe true
+    advanceUntilIdle()
+    verify(exactly = 1) { player.seekForward() }
+    verify(exactly = 0) { player.seekBack() }
+
+    callback.onMediaButtonEvent(session, controller, mediaKey(KeyEvent.KEYCODE_MEDIA_PREVIOUS)) shouldBe true
+    advanceUntilIdle()
+    verify(exactly = 1) { player.seekBack() }
+    verify(exactly = 1) { player.seekForward() }
+  }
+
+  @Test
+  fun `Android Automotive next and previous ignore reversed headset actions`() = runTest {
+    val player = mockk<VoicePlayer>(relaxed = true)
+    val callback = mediaButtonCallback(player, this)
+    val controller = mockk<MediaSession.ControllerInfo>()
+    val session = mockk<MediaSession>(relaxed = true) {
+      every { isAutomotiveController(controller) } returns true
+    }
+
+    callback.onMediaButtonEvent(session, controller, mediaKey(KeyEvent.KEYCODE_MEDIA_NEXT)) shouldBe true
+    advanceUntilIdle()
+    verify(exactly = 1) { player.seekForward() }
+    verify(exactly = 0) { player.seekBack() }
+
+    callback.onMediaButtonEvent(session, controller, mediaKey(KeyEvent.KEYCODE_MEDIA_PREVIOUS)) shouldBe true
+    advanceUntilIdle()
+    verify(exactly = 1) { player.seekBack() }
+    verify(exactly = 1) { player.seekForward() }
+  }
+
+  @Test
+  fun `headset next and previous retain configured actions`() = runTest {
+    val player = mockk<VoicePlayer>(relaxed = true)
+    val callback = mediaButtonCallback(player, this)
+    val session = mockk<MediaSession>(relaxed = true)
+    val controller = mockk<MediaSession.ControllerInfo>()
+
+    callback.onMediaButtonEvent(session, controller, mediaKey(KeyEvent.KEYCODE_MEDIA_NEXT)) shouldBe true
+    advanceUntilIdle()
+    verify(exactly = 1) { player.seekBack() }
+    verify(exactly = 0) { player.seekForward() }
+
+    callback.onMediaButtonEvent(session, controller, mediaKey(KeyEvent.KEYCODE_MEDIA_PREVIOUS)) shouldBe true
+    advanceUntilIdle()
+    verify(exactly = 1) { player.seekForward() }
+    verify(exactly = 1) { player.seekBack() }
+  }
+
+  @Test
+  fun `car key up and repeat events are consumed without seeking`() = runTest {
+    val player = mockk<VoicePlayer>(relaxed = true)
+    val callback = mediaButtonCallback(player, this)
+    val controller = mockk<MediaSession.ControllerInfo>()
+    val session = mockk<MediaSession>(relaxed = true) {
+      every { isAutoCompanionController(controller) } returns true
+    }
+
+    for (keyCode in listOf(KeyEvent.KEYCODE_MEDIA_NEXT, KeyEvent.KEYCODE_MEDIA_PREVIOUS)) {
+      callback.onMediaButtonEvent(session, controller, mediaKey(keyCode, KeyEvent.ACTION_UP)) shouldBe true
+      callback.onMediaButtonEvent(session, controller, mediaKey(keyCode, repeat = 1)) shouldBe true
+    }
+    advanceUntilIdle()
+    verify(exactly = 0) { player.seekForward() }
+    verify(exactly = 0) { player.seekBack() }
+  }
+
+  private fun mediaButtonCallback(
+    player: VoicePlayer,
+    scope: CoroutineScope,
+  ) = LibrarySessionCallback(
+    mediaItemProvider = mockk(),
+    scope = scope,
+    player = player,
+    bookSearchParser = mockk(),
+    bookSearchHandler = mockk(),
+    currentBookStoreId = mockk(),
+    bookRepository = mockk(),
+    doubleClickHandlerStore = MemoryDataStore(MediaButtonClickAction.SKIP_BACKWARD),
+    tripleClickHandlerStore = MemoryDataStore(MediaButtonClickAction.SKIP_FORWARD),
+    bookmarkRepo = mockk(),
+    intentHolder = mockk(),
+    positionUpdater = mockk(),
+    context = mockk(),
+  )
+
+  private fun mediaKey(
+    keyCode: Int,
+    action: Int = KeyEvent.ACTION_DOWN,
+    repeat: Int = 0,
+  ) = Intent(Intent.ACTION_MEDIA_BUTTON).putExtra(
+    Intent.EXTRA_KEY_EVENT,
+    KeyEvent(0, 0, action, keyCode, repeat, 0, -1, 0),
+  )
 
   @Test
   fun `lockscreen timed skip commands seek back and forward`() {

--- a/fastlane/metadata/android/en-US/changelogs/5408004.txt
+++ b/fastlane/metadata/android/en-US/changelogs/5408004.txt
@@ -1,0 +1,3 @@
+- Fixed later Chapter Fix corrections changing earlier chapter names or undoing restored names.
+- Restored long-press menus in search results. Thanks @JamesDBartlett3.
+- Fixed reversed Android Auto forward/rewind keys while preserving headset preferences. Thanks @geofgowan.

--- a/features/bookOverview/src/main/kotlin/voice/features/bookOverview/search/BookSearchScreen.kt
+++ b/features/bookOverview/src/main/kotlin/voice/features/bookOverview/search/BookSearchScreen.kt
@@ -39,6 +39,7 @@ internal fun BookSearchContent(
   contentPadding: PaddingValues,
   onQueryChange: (String) -> Unit,
   onBookClick: (BookId) -> Unit,
+  onBookLongClick: (BookId) -> Unit,
 ) {
   when (viewState) {
     is BookSearchViewState.EmptySearch -> {
@@ -88,7 +89,7 @@ internal fun BookSearchContent(
                 ListBookRow(
                   book = book,
                   onBookClick = onBookClick,
-                  onBookLongClick = onBookClick,
+                  onBookLongClick = onBookLongClick,
                   sharedTransitionScope = sharedTransitionScope,
                 )
               }
@@ -106,7 +107,7 @@ internal fun BookSearchContent(
                 GridBook(
                   book = book,
                   onBookClick = onBookClick,
-                  onBookLongClick = onBookClick,
+                  onBookLongClick = onBookLongClick,
                   sharedTransitionScope = sharedTransitionScope,
                 )
               }

--- a/features/bookOverview/src/main/kotlin/voice/features/bookOverview/views/BookOverview.kt
+++ b/features/bookOverview/src/main/kotlin/voice/features/bookOverview/views/BookOverview.kt
@@ -220,6 +220,12 @@ fun BookOverviewScreen(
       scrollState.capture(viewState.layoutMode, listState, gridState)
       bookOverviewViewModel.onSearchBookClick(bookId)
     },
+    onSearchBookLongClick = { bookId ->
+      scope.launch {
+        bottomSheetViewModel.bookSelected(bookId)
+        showBottomSheet = true
+      }
+    },
     onPermissionBugCardClick = bookOverviewViewModel::onPermissionBugCardClick,
     categoryExpanded = { category ->
       when (category) {
@@ -290,6 +296,7 @@ internal fun BookOverview(
   onSearchActiveChange: (Boolean) -> Unit,
   onSearchQueryChange: (String) -> Unit,
   onSearchBookClick: (BookId) -> Unit,
+  onSearchBookLongClick: (BookId) -> Unit,
   onPermissionBugCardClick: () -> Unit,
   categoryExpanded: (BookOverviewCategory) -> Boolean,
   onCategoryToggle: (BookOverviewCategory) -> Unit,
@@ -307,6 +314,7 @@ internal fun BookOverview(
         onActiveChange = onSearchActiveChange,
         onQueryChange = onSearchQueryChange,
         onSearchBookClick = onSearchBookClick,
+        onSearchBookLongClick = onSearchBookLongClick,
       )
     },
     floatingActionButton = {
@@ -380,6 +388,7 @@ fun BookOverviewPreview(
       onSearchActiveChange = {},
       onSearchQueryChange = {},
       onSearchBookClick = {},
+      onSearchBookLongClick = {},
       onPermissionBugCardClick = {},
       categoryExpanded = { true },
       onCategoryToggle = {},

--- a/features/bookOverview/src/main/kotlin/voice/features/bookOverview/views/topbar/BookOverviewSearchBar.kt
+++ b/features/bookOverview/src/main/kotlin/voice/features/bookOverview/views/topbar/BookOverviewSearchBar.kt
@@ -23,6 +23,7 @@ internal fun ColumnScope.BookOverviewSearchBar(
   onBookFolderClick: () -> Unit,
   onSettingsClick: () -> Unit,
   onSearchBookClick: (BookId) -> Unit,
+  onSearchBookLongClick: (BookId) -> Unit,
   searchActive: Boolean,
   showAddBookHint: Boolean,
   showFolderPickerIcon: Boolean,
@@ -69,6 +70,7 @@ internal fun ColumnScope.BookOverviewSearchBar(
         contentPadding = PaddingValues(),
         onQueryChange = onQueryChange,
         onBookClick = onSearchBookClick,
+        onBookLongClick = onSearchBookLongClick,
       )
     },
   )

--- a/features/bookOverview/src/main/kotlin/voice/features/bookOverview/views/topbar/BookOverviewTopBar.kt
+++ b/features/bookOverview/src/main/kotlin/voice/features/bookOverview/views/topbar/BookOverviewTopBar.kt
@@ -32,6 +32,7 @@ internal fun BookOverviewTopBar(
   onActiveChange: (Boolean) -> Unit,
   onQueryChange: (String) -> Unit,
   onSearchBookClick: (BookId) -> Unit,
+  onSearchBookLongClick: (BookId) -> Unit,
 ) {
   Column {
     val horizontalPadding by animateDpAsState(
@@ -46,6 +47,7 @@ internal fun BookOverviewTopBar(
       onBookFolderClick = onBookFolderClick,
       onSettingsClick = onSettingsClick,
       onSearchBookClick = onSearchBookClick,
+      onSearchBookLongClick = onSearchBookLongClick,
       searchActive = viewState.searchActive,
       showAddBookHint = viewState.showAddBookHint,
       showFolderPickerIcon = viewState.showFolderPickerIcon,
@@ -95,6 +97,7 @@ private fun BookOverviewTopBarPreview() {
       onActiveChange = {},
       onQueryChange = {},
       onSearchBookClick = {},
+      onSearchBookLongClick = {},
     )
   }
 }

--- a/features/chapterEditor/src/main/kotlin/voice/features/chapterEditor/ChapterEditorViewModel.kt
+++ b/features/chapterEditor/src/main/kotlin/voice/features/chapterEditor/ChapterEditorViewModel.kt
@@ -209,6 +209,8 @@ public class ChapterEditorViewModel(
             )
           }
         }
+        // Freeze once per editor session so subsequent adjustments respect restored names.
+        if (chaptersToFreeze != null) chaptersToFreeze = emptyList()
         bookRepository.updateBook(bookId) { it.copy(chapterNameOffset = offset) }
       }
     }

--- a/features/chapterEditor/src/main/kotlin/voice/features/chapterEditor/ChapterEditorViewModel.kt
+++ b/features/chapterEditor/src/main/kotlin/voice/features/chapterEditor/ChapterEditorViewModel.kt
@@ -12,8 +12,11 @@ import dev.zacsweers.metro.AssistedInject
 import kotlinx.coroutines.flow.MutableStateFlow
 import kotlinx.coroutines.flow.distinctUntilChanged
 import kotlinx.coroutines.flow.filterNotNull
+import kotlinx.coroutines.flow.first
 import kotlinx.coroutines.flow.map
 import kotlinx.coroutines.launch
+import kotlinx.coroutines.sync.Mutex
+import kotlinx.coroutines.sync.withLock
 import voice.core.common.DispatcherProvider
 import voice.core.common.MainScope
 import voice.core.common.RetainedViewModel
@@ -36,6 +39,10 @@ public class ChapterEditorViewModel(
   @Assisted private val bookId: BookId,
 ) : RetainedViewModel(MainScope(dispatcherProvider)) {
   private val localOffset = MutableStateFlow<Int?>(null)
+  private val editMutex = Mutex()
+  private var initialOffset: Int? = null
+  private var chaptersBeforeCurrent = emptyList<ChapterItemState>()
+  private var chaptersToFreeze: List<ChapterItemState>? = null
 
   private val _editingChapter = mutableStateOf<ChapterItemState?>(null)
   internal val editingChapter: State<ChapterItemState?> get() = _editingChapter
@@ -67,7 +74,10 @@ public class ChapterEditorViewModel(
     // Seed the editable offset from the persisted value once the book first loads; thereafter
     // localOffset is the source of truth and every edit is persisted back to the book.
     remember(book.content.id) {
-      if (localOffset.value == null) localOffset.value = book.content.chapterNameOffset
+      if (localOffset.value == null) {
+        initialOffset = book.content.chapterNameOffset
+        localOffset.value = book.content.chapterNameOffset
+      }
       book.content.id
     }
     val offset = localOffset.collectAsState().value ?: book.content.chapterNameOffset
@@ -98,6 +108,7 @@ public class ChapterEditorViewModel(
         item
       }
     }
+    chaptersBeforeCurrent = items.take(currentChapterIndex)
 
     return ChapterEditorViewState(
       offset = offset,
@@ -109,18 +120,17 @@ public class ChapterEditorViewModel(
   }
 
   public fun onOffsetIncrement() {
-    localOffset.value = (localOffset.value ?: 0).let { if (it == Int.MAX_VALUE) it else it + 1 }
-    persistOffset()
+    val current = localOffset.value ?: 0
+    setOffset(if (current == Int.MAX_VALUE) current else current + 1)
   }
 
   public fun onOffsetDecrement() {
-    localOffset.value = (localOffset.value ?: 0).let { if (it == Int.MIN_VALUE) it else it - 1 }
-    persistOffset()
+    val current = localOffset.value ?: 0
+    setOffset(if (current == Int.MIN_VALUE) current else current - 1)
   }
 
   public fun onOffsetSet(value: Int) {
-    localOffset.value = value
-    persistOffset()
+    setOffset(value)
   }
 
   public fun onEditChapterClick(item: ChapterItemState) {
@@ -136,13 +146,19 @@ public class ChapterEditorViewModel(
     newName: String,
   ) {
     scope.launch {
-      overrideRepo.set(item.chapterId, item.markStartMs, bookId, newName.trim())
+      editMutex.withLock {
+        overrideRepo.set(item.chapterId, item.markStartMs, bookId, newName.trim())
+      }
       _editingChapter.value = null
     }
   }
 
   public fun onDeleteOverride(item: ChapterItemState) {
-    scope.launch { overrideRepo.delete(item.chapterId, item.markStartMs) }
+    scope.launch {
+      editMutex.withLock {
+        overrideRepo.delete(item.chapterId, item.markStartMs)
+      }
+    }
   }
 
   public fun onResetAllClick() {
@@ -153,8 +169,12 @@ public class ChapterEditorViewModel(
     _showResetConfirm.value = false
     localOffset.value = 0
     scope.launch {
-      bookRepository.updateBook(bookId) { it.copy(chapterNameOffset = 0) }
-      overrideRepo.deleteAll(bookId)
+      editMutex.withLock {
+        bookRepository.updateBook(bookId) { it.copy(chapterNameOffset = 0) }
+        overrideRepo.deleteAll(bookId)
+        initialOffset = 0
+        chaptersToFreeze = null
+      }
     }
   }
 
@@ -163,13 +183,32 @@ public class ChapterEditorViewModel(
   }
 
   public fun onBack() {
-    // Each offset change is already persisted by persistOffset(), so just navigate back.
+    // Each offset change is already persisted, so just navigate back.
     navigator.goBack()
   }
 
-  private fun persistOffset() {
+  private fun setOffset(offset: Int) {
+    if (localOffset.value == offset) return
+    // ponytail: Reuse existing overrides as range anchors; add a dedicated anchor table only if
+    // users need to edit or remove individual offset ranges later.
+    if (initialOffset?.let { it != 0 } == true && chaptersToFreeze == null) {
+      chaptersToFreeze = chaptersBeforeCurrent.filterNot { it.hasOverride }
+    }
+    localOffset.value = offset
     scope.launch {
-      localOffset.value?.let { offset ->
+      editMutex.withLock {
+        val existingOverrides = overrideRepo.overridesForBook(bookId).first().byMarkKey()
+        chaptersToFreeze.orEmpty().forEach { chapter ->
+          val key = Pair(chapter.chapterId.value, chapter.markStartMs)
+          if (key !in existingOverrides) {
+            overrideRepo.set(
+              chapterId = chapter.chapterId,
+              markStartMs = chapter.markStartMs,
+              bookId = bookId,
+              name = chapter.displayName,
+            )
+          }
+        }
         bookRepository.updateBook(bookId) { it.copy(chapterNameOffset = offset) }
       }
     }

--- a/features/chapterEditor/src/test/kotlin/voice/features/chapterEditor/ChapterEditorViewModelTest.kt
+++ b/features/chapterEditor/src/test/kotlin/voice/features/chapterEditor/ChapterEditorViewModelTest.kt
@@ -160,6 +160,11 @@ class ChapterEditorViewModelTest {
     val overrideFlow = MutableStateFlow<List<ChapterNameOverride>>(emptyList())
     val overrideRepo = mockk<ChapterNameOverrideRepo> {
       every { overridesForBook(bookId) } returns overrideFlow
+      coEvery { delete(any(), any()) } answers {
+        val id = firstArg<ChapterId>().value
+        val start = secondArg<Long>()
+        overrideFlow.value = overrideFlow.value.filterNot { it.chapterId == id && it.markStartMs == start }
+      }
       coEvery { set(any(), any(), any(), any()) } answers {
         overrideFlow.value += ChapterNameOverride(
           chapterId = firstArg<ChapterId>().value,
@@ -191,6 +196,17 @@ class ChapterEditorViewModelTest {
       assertEquals(listOf(0L, 60_000L), overrideFlow.value.map { it.markStartMs })
       assertFalse(state.chapters[2].hasOverride)
       assertFalse(state.chapters[3].hasOverride)
+
+      // Restoring one preserved name must remain effective when adjusting the offset again.
+      vm.onDeleteOverride(state.chapters[0])
+      state = awaitNonNull()
+      while (state.chapters[0].hasOverride) state = awaitNonNull()
+      vm.onOffsetSet(-8)
+      state = awaitNonNull()
+      while (state.offset != -8) state = awaitNonNull()
+      assertEquals(listOf("Chapter 2", "Chapter 9", "Chapter 4", "Chapter 5"), state.chapters.map { it.displayName })
+      assertFalse(state.chapters[0].hasOverride)
+      coVerify(exactly = 1) { overrideRepo.set(chapterId, 0L, bookId, "Chapter 8") }
     }
   }
 

--- a/features/chapterEditor/src/test/kotlin/voice/features/chapterEditor/ChapterEditorViewModelTest.kt
+++ b/features/chapterEditor/src/test/kotlin/voice/features/chapterEditor/ChapterEditorViewModelTest.kt
@@ -146,6 +146,121 @@ class ChapterEditorViewModelTest {
   }
 
   @Test
+  fun `later correction preserves prior names and applies new offset from current chapter`() = runTest {
+    val chapter = chapter(
+      durationMs = 4.minutesMs(),
+      marks = listOf(
+        MarkData(startMs = 0L, name = "Chapter 10"),
+        MarkData(startMs = 60_000L, name = "Chapter 11"),
+        MarkData(startMs = 120_000L, name = "Chapter 12"),
+        MarkData(startMs = 180_000L, name = "Chapter 13"),
+      ),
+    )
+    val bookFlow = MutableStateFlow(book(chapters = listOf(chapter), offset = -2, positionInChapter = 130_000L))
+    val overrideFlow = MutableStateFlow<List<ChapterNameOverride>>(emptyList())
+    val overrideRepo = mockk<ChapterNameOverrideRepo> {
+      every { overridesForBook(bookId) } returns overrideFlow
+      coEvery { set(any(), any(), any(), any()) } answers {
+        overrideFlow.value += ChapterNameOverride(
+          chapterId = firstArg<ChapterId>().value,
+          markStartMs = secondArg(),
+          bookId = thirdArg<BookId>().value,
+          name = arg(3),
+        )
+      }
+    }
+    val bookRepository = mockk<BookRepository> {
+      every { flow(bookId) } returns bookFlow
+      coEvery { updateBook(bookId, any()) } answers {
+        val update = secondArg<(BookContent) -> BookContent>()
+        bookFlow.value = bookFlow.value.copy(content = update(bookFlow.value.content))
+      }
+    }
+    val vm = viewModel(bookFlow.value, overrideRepo = overrideRepo, bookRepository = bookRepository)
+
+    backgroundScope.launchMolecule(RecompositionMode.Immediate) { vm.viewState() }.test {
+      var state = awaitNonNull()
+      while (state.currentChapterIndex != 2) state = awaitNonNull()
+      assertEquals(listOf("Chapter 8", "Chapter 9", "Chapter 10", "Chapter 11"), state.chapters.map { it.displayName })
+
+      vm.onOffsetSet(-9)
+
+      state = awaitNonNull()
+      while (state.offset != -9 || state.chapters.take(2).any { !it.hasOverride }) state = awaitNonNull()
+      assertEquals(listOf("Chapter 8", "Chapter 9", "Chapter 3", "Chapter 4"), state.chapters.map { it.displayName })
+      assertEquals(listOf(0L, 60_000L), overrideFlow.value.map { it.markStartMs })
+      assertFalse(state.chapters[2].hasOverride)
+      assertFalse(state.chapters[3].hasOverride)
+    }
+  }
+
+  @Test
+  fun `first correction remains global and creates no frozen names`() = runTest {
+    val overrideRepo = mockk<ChapterNameOverrideRepo>(relaxed = true) {
+      every { overridesForBook(bookId) } returns MutableStateFlow(emptyList())
+    }
+    val chapter = chapter(
+      durationMs = 3.minutesMs(),
+      marks = listOf(
+        MarkData(startMs = 0L, name = "Chapter 10"),
+        MarkData(startMs = 60_000L, name = "Chapter 11"),
+        MarkData(startMs = 120_000L, name = "Chapter 12"),
+      ),
+    )
+    val vm = viewModel(
+      book = book(chapters = listOf(chapter), offset = 0, positionInChapter = 130_000L),
+      overrideRepo = overrideRepo,
+    )
+
+    backgroundScope.launchMolecule(RecompositionMode.Immediate) { vm.viewState() }.test {
+      var state = awaitNonNull()
+      while (state.currentChapterIndex != 2) state = awaitNonNull()
+
+      vm.onOffsetSet(-2)
+      state = awaitNonNull()
+      while (state.offset != -2) state = awaitNonNull()
+
+      assertEquals(listOf("Chapter 8", "Chapter 9", "Chapter 10"), state.chapters.map { it.displayName })
+      coVerify(exactly = 0) { overrideRepo.set(any(), any(), any(), any()) }
+    }
+  }
+
+  @Test
+  fun `later correction does not replace manual names`() = runTest {
+    val chapter = chapter(
+      durationMs = 3.minutesMs(),
+      marks = listOf(
+        MarkData(startMs = 0L, name = "Chapter 10"),
+        MarkData(startMs = 60_000L, name = "Chapter 11"),
+        MarkData(startMs = 120_000L, name = "Chapter 12"),
+      ),
+    )
+    val manual = ChapterNameOverride(chapterId.value, 0L, bookId.value, "Prologue")
+    val overrideFlow = MutableStateFlow(listOf(manual))
+    val overrideRepo = mockk<ChapterNameOverrideRepo>(relaxed = true) {
+      every { overridesForBook(bookId) } returns overrideFlow
+    }
+    val vm = viewModel(
+      book = book(chapters = listOf(chapter), offset = -2, positionInChapter = 130_000L),
+      overrides = listOf(manual),
+      overrideRepo = overrideRepo,
+    )
+
+    backgroundScope.launchMolecule(RecompositionMode.Immediate) { vm.viewState() }.test {
+      var state = awaitNonNull()
+      while (state.currentChapterIndex != 2 || !state.chapters[0].hasOverride) state = awaitNonNull()
+
+      vm.onOffsetSet(-9)
+      state = awaitNonNull()
+      while (state.offset != -9) state = awaitNonNull()
+
+      assertEquals("Prologue", state.chapters[0].displayName)
+      coVerify(exactly = 0) { overrideRepo.set(chapterId, 0L, bookId, any()) }
+      coVerify { overrideRepo.set(chapterId, 60_000L, bookId, "Chapter 9") }
+    }
+  }
+
+  @Test
   fun `override takes precedence over offset`() = runTest {
     val override = ChapterNameOverride(
       chapterId = chapterId.value,


### PR DESCRIPTION
## Summary

- Preserve earlier chapter names when applying a later Chapter Fix correction, and respect names explicitly restored during subsequent adjustments.
- Restore the long-press context menu in grid and list search results. Search-only extraction from #19; original authorship and @JamesDBartlett3's co-author credit are retained. The playback-speed changes from that PR are excluded because v1.26 already addressed that issue.
- Keep Android Auto/Automotive forward and rewind media keys directional while preserving configurable headset actions. Addresses the reversed physical keys reported by @geofgowan in #20; the separate request for on-screen seek buttons is not included.

## Verification

- Full local unit suite: 1,038 executions across variants, zero failures/errors/skips.
- Lint and Kotlin instrumentation-source checks passed.
- 12 emulator tests passed: five existing app/navigation smoke tests, three real-audio playback/sleep-timer tests, search in both layouts and chapter correction/reset, and car/headset media-key integration.
- Debug build installed on the connected phone for user testing.
- New feature and media-key regression tests added to CI.
- Car integration uses real player/session dependencies with synthetic controller identities; real head-unit validation remains distinct from these emulator checks.

## Release pathway

Version 1.27 / code 5408004. Preserve the existing production application ID, signing configuration, F-Droid tag detection, and `app-libre-release-signed.apk` asset name. Merge using a merge commit to preserve contribution history; publish through the existing `v1.27` tag-triggered Release workflow after checks pass.
